### PR TITLE
Spelling of Do Not Disturb (capital N and D)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,6 @@
 	<string name="intro_add_tile">2. Add the tile to your quick settings:</string>
 	<string name="add_tile">Add tile</string>
 	<string name="tile_added">Tile added</string>
-	<string name="do_not_disturb">Do not disturb</string>
+	<string name="do_not_disturb">Do Not Disturb</string>
 	<string name="tile_no_permission">No permission</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
 	<string name="app_name">DND Toggle</string>
-	<string name="intro">This tiny app adds a quick settings tile to allow you to toggle the \"Do not disturb\" mode with just one tap, just like you were able to for more than a decade before Google decided to do the stupid thing in Android 15 QPR2 with its \"Modes\" feature.</string>
+	<string name="intro">This tiny app adds a quick settings tile to allow you to toggle the \"Do Not Disturb\" mode with just one tap, just like you were able to for more than a decade before Google decided to do the stupid thing in Android 15 QPR2 with its \"Modes\" feature.</string>
 	<string name="intro_permission">1. Grant the app the permission to manage your notifications policy:</string>
 	<string name="open_settings">Open settings</string>
 	<string name="permission_granted">Permission granted</string>


### PR DESCRIPTION
Just a very small thing I noticed, the original system tile (and now modes) calls it `Do Not Disturb` instead of `Do not disturb`. 

* [`app/src/main/res/values/strings.xml`](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103L3-R10): Updated the capitalization of "Do Not Disturb" in the `intro` and `do_not_disturb` strings.

Just a suggestion, and thank you for the app!